### PR TITLE
For info: Possible adjustment local_deployable_binaries.zip case

### DIFF
--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -231,7 +231,7 @@
                         <configuration>
                             <exportAntProperties>true</exportAntProperties>
                             <skip>${without.static}</skip>
-                            <target>
+                            <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <macrodef name="getfrontend">
                                     <attribute name="src"/>
                                     <sequential>
@@ -245,10 +245,6 @@
                                 </macrodef>
                                 <macrodef name="zipfrontendbin">
                                     <sequential>
-                                        <pathconvert property="frontend.repo.path">
-                                            <map from="${basedir}/file:" to=""/>
-                                            <path location="${frontend.repo}"/>
-                                        </pathconvert>
                                         <echo level="info">Frontend Repo Path: ${frontend.repo.path}</echo>
                                         <mkdir dir="${project.build.directory}/frontend-bin"/>
                                         <copy todir="${project.build.directory}/frontend-bin" failonerror="false" quiet="true"><fileset dir="${frontend.repo.path}"/></copy>
@@ -256,12 +252,22 @@
                                         <delete dir="${project.build.directory}/frontend-bin" quiet="true"/>
                                     </sequential>
                                 </macrodef>
-                                <zipfrontendbin/>
+                                <pathconvert property="frontend.repo.path">
+                                    <map from="${basedir}/file:" to=""/>
+                                    <path location="${frontend.repo}"/>
+                                </pathconvert>
                                 <getfrontend src="${frontend.repo}/releases/download/${frontend.tag}/${frontend.tag}.zip"/>
                                 <getfrontend src="${frontend.repo}/releases/download/${frontend.tag}/deployable_binaries.zip"/>
                                 <getfrontend src="${frontend.repo}/archive/refs/tags/${frontend.tag}.zip"/>
                                 <getfrontend src="${frontend.repo}/archive/${frontend.tag}.zip"/>
                                 <getfrontend src="${frontend.repo}/archive/refs/heads/development_3.0.zip"/>
+                                <condition property="frontend.zip.exists">
+                                    <available file="${project.build.directory}/frontend.zip" type="file"/>
+                                </condition>
+                                <condition property="frontend.repo.path.exists">
+                                    <available file="${frontend.repo.path}" type="dir"/>
+                                </condition>
+                                <zipfrontendbin if:set="frontend.repo.path.exists" unless:set="frontend.zip.exists"/>
                                 <unzip src="${project.build.directory}/frontend.zip" dest="${project.build.directory}"/>
                                 <delete file="${project.build.directory}/frontend.zip"/>
                                 <move file="${project.build.directory}/dist" tofile="${project.build.directory}/GSRSFrontend" failonerror="false" quiet="true"/>


### PR DESCRIPTION
I tested the branch ep_frontend_pom. 

In my tests, it worked **except** in the case where the user supplies something like  local_deployable_binaries.zip 

```
# local_deployable_binaries.zip on files system
#  resolves to --> Getting: file:///path/to/my/directory/archive/local_deployable_binaries.zip
mvn clean -U package -DskipTests  -Dfrontend.repo=file:///path/to/my/directory   -Dfrontend.tag=local_deployable_binaries -Dwithout.visualizer
```

Providing this info/PR in case helpful  

Codex found the following and made changes that. include in this subbranch.  

```
  The issue was that <zipfrontendbin/> ran before the normal getfrontend URL attempts. For your file://.../frontend-bin repo, it zipped the whole
  local directory into target/frontend.zip, so the later real archive URL:

  file:///Users/welscha2/Documents/d/fda/gsrs3/ci/frontend-bin/archive/local_deployable_binaries.zip

  was skipped because <get> had skipexisting="true".

  I changed that local-directory zip behavior into a fallback that only runs after the normal archive/release URL checks fail. Verified with your
  Maven command: build finished with BUILD SUCCESS, the log showed Use deployable binaries: true, and all Node/npm executions were skipped. 
```  
I tested codex's fix with these scenariios:
 
```
# defaults to development_3.0
# ... works
 mvn clean -U package -DskipTests -Dfrontend.tag="" -Dwithout.visualizer

# as of today has no deployable_binaries.zip
# ... works 
 mvn clean -U package -DskipTests -Dfrontend.tag=GSRSv3.2.0PUB -Dwithout.visualizer

# has a deployable_binaries.zip
# ... works
 mvn clean -U package -DskipTests -Dfrontend.tag=TESTREL-20260716 -Dwithout.visualizer

# local_deployable_binaries.zip on files system
#  resolves to --> Getting: file:///path/to/my/directory/archive/local_deployable_binaries.zip
#  works
mvn clean -U package -DskipTests  -Dfrontend.repo=file:///path/to/my/directory   -Dfrontend.tag=local_deployable_binaries -Dwithout.visualizer
```
 